### PR TITLE
[1.x] Fix dependency overloading when using outside of typical Laravel installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "require": {
     "php": "^8.0",
-    "laravel/framework": "9.*|10.*"
+    "illuminate/contracts": "9.*|10.*"
   },
   "require-dev": {
     "orchestra/testbench": "^7.0 || ^8.0",


### PR DESCRIPTION
## About

The `laravel/framework` is a hard constraint that will prevent dependencies from being properly loaded in a non-standard Laravel installation. Such installations are, for example, non-official [Laravel Zero](https://laravel-zero.com) which is based on Laravel's [Illuminate](https://github.com/illuminate) components, but it doesn't use Laravel directly.

---
